### PR TITLE
Replace deprecated np.math alias with math

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/channel/diffraction/diffraction.py
+++ b/channel/diffraction/diffraction.py
@@ -5,6 +5,7 @@ Created on Wed Dec 15 00:14:35 2021
 @author: Duncan McArthur
 """
 
+import math
 from scipy.integrate import quad
 from scipy.special import j0
 import numpy as np
@@ -30,7 +31,7 @@ def GaussianMode(r,w0):
         Gaussian amplitude.
 
     """
-    return np.math.sqrt(2/np.pi) * np.exp(-(r/w0)**2) / w0
+    return math.sqrt(2/np.pi) * np.exp(-(r/w0)**2) / w0
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/key/error_correction/functions.py
+++ b/key/error_correction/functions.py
@@ -5,6 +5,7 @@ Created on Tue May  2 10:15:35 2023
 @author: Duncan McArthur
 """
 
+import math
 import numpy as np
 from scipy.stats import binom
 
@@ -61,8 +62,8 @@ def logM(nX, QBERx, eps_c):
 
     """
     lM = nX * h(QBERx) + (nX * (1.0 - QBERx) - FInv(int(nX), QBERx, eps_c) - \
-                          1) * np.math.log((1.0 - QBERx) / QBERx) - \
-        0.5*np.math.log(nX) - np.math.log(1.0 / eps_c)
+                          1) * math.log((1.0 - QBERx) / QBERx) - \
+        0.5*math.log(nX) - math.log(1.0 / eps_c)
     return lM
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/key/get_key.py
+++ b/key/get_key.py
@@ -7,6 +7,7 @@ Created on Fri Jan 21 14:54:00 2022
 
 from sys import float_info
 
+import math
 import numpy as np
 from scipy.optimize import minimize
 
@@ -780,12 +781,12 @@ def SKL_main_loop(main_params,adv_params,x,x0i,xb,ci,ni,f_atm,bounds,cons,
 
         # Nominal system loss: based on zenith coupling efficiency and nominal losses
         # if xi == 0.0:
-        #     sysLoss = -10*(np.math.log10(FSeff[time0pos]) + np.math.log10(eta))
+        #     sysLoss = -10*(math.log10(FSeff[time0pos]) + math.log10(eta))
         # else:
         #     slm     = eta_loss_metric(hsat,h0,wvl,aT,aR,w0,f_atm,eta_int)
-        #     sysLoss = slm - 10*np.math.log10(eta)
-        sysLoss = -10*(np.math.log10(FSeff[time0pos]) + 
-                       np.math.log10(main_params['fixed']['eta']))
+        #     sysLoss = slm - 10*math.log10(eta)
+        sysLoss = -10*(math.log10(FSeff[time0pos]) + 
+                       math.log10(main_params['fixed']['eta']))
 
         # Maximum elevation angle (degs) of satellite pass
         #max_elev = np.degrees(cvs[time0pos,1])

--- a/key/maths.py
+++ b/key/maths.py
@@ -5,7 +5,7 @@ Created on Tue May  2 15:45:03 2023
 @author: Duncan McArthur
 """
 
-import numpy as np
+import math
 
 __all__ = ['gamma','h','heaviside']
 
@@ -27,7 +27,7 @@ def h(x):
         Binary entropy.
 
     """
-    h = -x*np.math.log(x, 2) - (1 - x)*np.math.log(1 - x, 2)
+    h = -x*math.log(x, 2) - (1 - x)*math.log(1 - x, 2)
     return h
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -54,9 +54,9 @@ def gamma(a,b,c,d):
         Output value.
 
     """
-    g1 = max((c + d) * (1 - b) * b / (c*d * np.math.log(2)), 0.0)
+    g1 = max((c + d) * (1 - b) * b / (c*d * math.log(2)), 0.0)
     g2 = max((c + d) * 21**2 / (c*d * (1 - b) * b*a**2), 1.0)
-    g  = np.math.sqrt(g1 * np.math.log(g2, 2))
+    g  = math.sqrt(g1 * math.log(g2, 2))
     return g
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/key/protocols/func_efficient_BB84.py
+++ b/key/protocols/func_efficient_BB84.py
@@ -5,6 +5,7 @@ Created on Wed Dec 15 01:56:35 2021
 @author: Duncan McArthur
 """
 
+import math
 import numpy as np
 
 __all__ = ['DRate_j','error_j','nxz','mXZ','mxz','nXZpm','nXZpm_HB','nXZpm_inf',
@@ -181,7 +182,7 @@ def nXZpm(mu,P,nxz_mu,eps_s):
         sifted X/Z basis.
 
     """
-    log_21es = np.math.log(21.0 / eps_s)
+    log_21es = math.log(21.0 / eps_s)
     term_m   = 0.5*log_21es + np.sqrt(2*nxz_mu*log_21es + 0.25*log_21es**2)
     term_p   = log_21es + np.sqrt(2*nxz_mu*log_21es + log_21es**2)
 
@@ -221,7 +222,7 @@ def nXZpm_HB(mu,P,nxz_mu,nXZ,eps_s):
         sifted X/Z basis.
 
     """
-    term2   = np.sqrt(0.5*nXZ * np.math.log(21.0 / eps_s))
+    term2   = np.sqrt(0.5*nXZ * math.log(21.0 / eps_s))
     nXZmin  = np.divide(np.multiply(np.exp(mu), nxz_mu - term2), P)
     nXZplus = np.divide(np.multiply(np.exp(mu), nxz_mu + term2), P)
     return nXZmin, nXZplus
@@ -282,8 +283,8 @@ def tau(n,mu,P):
         exit(1)
     tau = 0
     for jj in range(len(mu)):
-        tau += np.math.exp(-mu[jj]) * mu[jj]**n * P[jj]
-    tau = tau / np.math.factorial(n)
+        tau += math.exp(-mu[jj]) * mu[jj]**n * P[jj]
+    tau = tau / math.factorial(n)
     return tau
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -384,7 +385,7 @@ def mXZpm(mu,P,mXZj,eps_s):
         sifted X/Z basis.
 
     """
-    log_21es = np.math.log(21.0 / eps_s)
+    log_21es = math.log(21.0 / eps_s)
     term_m  = 0.5*log_21es + np.sqrt(2*mXZj*log_21es + 0.25*log_21es**2)
     term_p  = log_21es + np.sqrt(2*mXZj*log_21es + log_21es**2)
 

--- a/key/protocols/key_efficient_BB84.py
+++ b/key/protocols/key_efficient_BB84.py
@@ -11,6 +11,7 @@ num_min = float_info.epsilon # round (relative error due to rounding)
 # Extract the largest float that the current system can represent
 num_max = float_info.max
 
+import math
 import numpy as np
 
 from ..maths import (h, heaviside, gamma)
@@ -410,7 +411,7 @@ def key_length(x, args):
         phi_x = min(ratio + gamma(eps_s,ratio,sz1,sx1), 0.5)
         # Secret key length in the finite regime
         l = max((sx0 + sx1 * (1 - h(phi_x)) - lambdaEC -
-             6*np.math.log(21.0 / eps_s, 2) - np.math.log(2.0 / eps_c, 2)) * 
+             6*math.log(21.0 / eps_s, 2) - math.log(2.0 / eps_c, 2)) * 
              heaviside(mu[0] - mu[1] - mu[2]) * heaviside(P[2]), 0.0)
         l = l / NoPass # Normalise by the number of satellite passes used
 


### PR DESCRIPTION
Hi,
I had an issue with SatQuMA where using the current version of numpy (2.2.3) resulted in `AttributeError: module 'numpy' has no attribute 'math'`.

I found `np.math` being used throughout the code, which worked with older versions of numpy (1.26.4) where `numpy` provided an alias for the `math` module, however this alias has been listed as deprecated in numpy 1.25 and has since been removed in a later version.

I've went through and replaced all instances of `np.math` with `math`, which fixes this issue. I've tested SatQuMA against numpy 1.26.4 and 2.2.3 with this change and it now works the same with both versions and provides the same results.

Hope this helps!

Kind regards,
Faris

Edinburgh Mostly Quantum Lab